### PR TITLE
tomcat changes

### DIFF
--- a/cpo-jdbc/src/main/java/org/synchronoss/cpo/jdbc/JndiJdbcDataSourceInfo.java
+++ b/cpo-jdbc/src/main/java/org/synchronoss/cpo/jdbc/JndiJdbcDataSourceInfo.java
@@ -66,7 +66,15 @@ public class JndiJdbcDataSourceInfo extends AbstractJdbcDataSourceInfo {
       if (jndiCtx == null) {
         jndiCtx = new InitialContext();
       }
-      datasource = (DataSource)jndiCtx.lookup(jndiName);
+      try {
+        datasource = (DataSource) jndiCtx.lookup(jndiName);
+      } catch (NamingException e) {
+
+        Context initCtx = (Context)
+            jndiCtx.lookup("java:/comp/env");
+        datasource = (DataSource)
+            initCtx.lookup(jndiName);
+      }
     } catch (Exception e) {
       throw new CpoException("Error instantiating DataSource", e);
     }


### PR DESCRIPTION
in order to do a jndi lookup in the tomcat environment, we need to do
an additional lookup on the "java:/comp/env" without which the jndi
lookup fails.