### PR TITLE
moved the CpoAdapterFactory map in CpoAdapterFactoryManager to cpo.ca…

### DIFF
--- a/cpo-core/src/main/java/org/synchronoss/cpo/CpoAdapterFactoryManager.java
+++ b/cpo-core/src/main/java/org/synchronoss/cpo/CpoAdapterFactoryManager.java
@@ -22,6 +22,7 @@ package org.synchronoss.cpo;
 
 import org.apache.xmlbeans.XmlException;
 import org.slf4j.*;
+import org.synchronoss.cpo.cache.CpoAdapterFactoryCache;
 import org.synchronoss.cpo.config.CpoConfigProcessor;
 import org.synchronoss.cpo.core.cpoCoreConfig.*;
 import org.synchronoss.cpo.helper.*;
@@ -34,11 +35,10 @@ import java.util.*;
 /**
  * @author dberry
  */
-public final class CpoAdapterFactoryManager {
+public final class CpoAdapterFactoryManager extends CpoAdapterFactoryCache {
 
   private static final Logger logger = LoggerFactory.getLogger(CpoAdapterFactoryManager.class);
   private static final String CPO_CONFIG_XML = "/cpoConfig.xml";
-  private static volatile Map<String, CpoAdapterFactory> adapterMap = new HashMap<>();
   private static String defaultContext = null;
 
   static {
@@ -51,7 +51,7 @@ public final class CpoAdapterFactoryManager {
 
   public static CpoAdapter getCpoAdapter(String context) throws CpoException {
     CpoAdapter cpoAdapter=null;
-    CpoAdapterFactory cpoAdapterFactory = adapterMap.get(context);
+    CpoAdapterFactory cpoAdapterFactory = findCpoAdapterFactory(context);
     if (cpoAdapterFactory != null) {
       cpoAdapter = cpoAdapterFactory.getCpoAdapter();
     }
@@ -64,7 +64,7 @@ public final class CpoAdapterFactoryManager {
 
   public static CpoTrxAdapter getCpoTrxAdapter(String context) throws CpoException {
     CpoTrxAdapter cpoTrxAdapter=null;
-    CpoAdapterFactory cpoAdapterFactory = adapterMap.get(context);
+    CpoAdapterFactory cpoAdapterFactory = findCpoAdapterFactory(context);
     if (cpoAdapterFactory != null) {
       cpoTrxAdapter = cpoAdapterFactory.getCpoTrxAdapter();
     }
@@ -77,7 +77,7 @@ public final class CpoAdapterFactoryManager {
 
   public static CpoXaResource getCpoXaAdapter(String context) throws CpoException {
     CpoXaResource cpoXaResource =null;
-    CpoAdapterFactory cpoAdapterFactory = adapterMap.get(context);
+    CpoAdapterFactory cpoAdapterFactory = findCpoAdapterFactory(context);
     if (cpoAdapterFactory != null) {
       cpoXaResource = cpoAdapterFactory.getCpoXaAdapter();
     }
@@ -102,7 +102,7 @@ public final class CpoAdapterFactoryManager {
     try {
       // We are doing a load clear all the caches first, in case the load gets called more than once.
       CpoMetaDescriptor.clearAllInstances();
-      adapterMap.clear();
+      clearCpoAdapterFactoryCache();
 
       CpoConfigDocument configDoc;
       if (is == null) {
@@ -139,7 +139,7 @@ public final class CpoAdapterFactoryManager {
         for (CtDataSourceConfig dataSourceConfig : cpoConfig.getDataConfigArray()) {
           CpoAdapterFactory cpoAdapterFactory = makeCpoAdapterFactory(dataSourceConfig);
           if (cpoAdapterFactory != null) {
-            adapterMap.put(dataSourceConfig.getName(), cpoAdapterFactory);
+            addCpoAdapterFactory(dataSourceConfig.getName(), cpoAdapterFactory);
           }
         }
       }

--- a/cpo-core/src/main/java/org/synchronoss/cpo/cache/CpoAdapterFactoryCache.java
+++ b/cpo-core/src/main/java/org/synchronoss/cpo/cache/CpoAdapterFactoryCache.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2003-2012 David E. Berry
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * A copy of the GNU Lesser General Public License may also be found at
+ * http://www.gnu.org/licenses/lgpl.txt
+ */
+package org.synchronoss.cpo.cache;
+
+import org.synchronoss.cpo.CpoAdapterFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author dberry
+ */
+public class CpoAdapterFactoryCache {
+
+  private static final Map<String, CpoAdapterFactory> adapterMap = new HashMap<>();
+
+  protected static CpoAdapterFactory findCpoAdapterFactory(String adapterKey) {
+    CpoAdapterFactory adapter = null;
+
+    if (adapterKey != null) {
+      adapter = adapterMap.get(adapterKey);
+    }
+
+    return adapter;
+  }
+
+  protected static CpoAdapterFactory addCpoAdapterFactory(String adapterKey, CpoAdapterFactory adapter) {
+    CpoAdapterFactory oldAdapter = null;
+
+    if (adapterKey != null && adapter != null) {
+      oldAdapter = adapterMap.put(adapterKey, adapter);
+    }
+
+    return oldAdapter;
+  }
+
+  protected static void clearCpoAdapterFactoryCache() {
+    adapterMap.clear();
+  }
+
+}


### PR DESCRIPTION
In keeping with the pattern of having maps used for caching in org.synchronoss.cpo.cache, I 
moved the CpoAdapterFactory map in CpoAdapterFactoryManager to cpo.cache.CpoAdapterFactoryCache