### PR TITLE
Updated CPO to be compliant with JDBC 4.3

### DIFF
--- a/cpo-cassandra/src/main/java/org/synchronoss/cpo/cassandra/CassandraCpoAdapter.java
+++ b/cpo-cassandra/src/main/java/org/synchronoss/cpo/cassandra/CassandraCpoAdapter.java
@@ -1634,7 +1634,7 @@ public class CassandraCpoAdapter extends CpoBaseAdapter<ClusterDataSource> {
   @Override
   public <T, C> CpoResultSet<T> retrieveBeans(String name, C criteria, T result, Collection<CpoWhere> wheres, Collection<CpoOrderBy> orderBy, Collection<CpoNativeFunction> nativeExpressions, int queueSize) throws CpoException {
     CpoBlockingResultSet<T> resultSet = new CpoBlockingResultSet<>(queueSize);
-    RetrieverThread<T, C> retrieverThread = new RetrieverThread<>(name, criteria, result, wheres, orderBy, nativeExpressions, false, resultSet);
+    RetrieverThread<T, C> retrieverThread = new RetrieverThread<T, C>(name, criteria, result, wheres, orderBy, nativeExpressions, false, resultSet);
 
     retrieverThread.start();
     return resultSet;
@@ -2281,7 +2281,7 @@ public class CassandraCpoAdapter extends CpoBaseAdapter<ClusterDataSource> {
             CpoAttribute attribute = cpoClass.getAttributeData(row.getString(0));
 
             if (attribute != null) {
-              attribute.invokeSetter(rObj, new ResultSetCpoData(CassandraMethodMapper.getMethodMapper(), row, attribute, 1));
+              attribute.invokeSetter(rObj, new CassandraResultSetCpoData(CassandraMethodMapper.getMethodMapper(), row, attribute, 1));
               attributesSet++;
             }
           }
@@ -2293,7 +2293,7 @@ public class CassandraCpoAdapter extends CpoBaseAdapter<ClusterDataSource> {
             CpoAttribute attribute = cpoClass.getAttributeData(columnDefs.getName(k));
 
             if (attribute != null) {
-              attribute.invokeSetter(rObj, new ResultSetCpoData(CassandraMethodMapper.getMethodMapper(), row, attribute, k));
+              attribute.invokeSetter(rObj, new CassandraResultSetCpoData(CassandraMethodMapper.getMethodMapper(), row, attribute, k));
               attributesSet++;
             }
           }
@@ -2436,7 +2436,7 @@ public class CassandraCpoAdapter extends CpoBaseAdapter<ClusterDataSource> {
 
            for (int k = 0; k < columnCount; k++) {
              if (attributes[k] != null) {
-               attributes[k].invokeSetter(obj, new ResultSetCpoData(CassandraMethodMapper.getMethodMapper(), row, attributes[k], k));
+               attributes[k].invokeSetter(obj, new CassandraResultSetCpoData(CassandraMethodMapper.getMethodMapper(), row, attributes[k], k));
              }
            }
 

--- a/cpo-cassandra/src/main/java/org/synchronoss/cpo/cassandra/meta/CassandraResultSetCpoData.java
+++ b/cpo-cassandra/src/main/java/org/synchronoss/cpo/cassandra/meta/CassandraResultSetCpoData.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2003-2012 David E. Berry
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * A copy of the GNU Lesser General Public License may also be found at
+ * http://www.gnu.org/licenses/lgpl.txt
+ */
+package org.synchronoss.cpo.cassandra.meta;
+
+import org.synchronoss.cpo.meta.MethodMapEntry;
+import org.synchronoss.cpo.meta.MethodMapper;
+import org.synchronoss.cpo.meta.ResultSetCpoData;
+import org.synchronoss.cpo.meta.domain.CpoAttribute;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class CassandraResultSetCpoData extends ResultSetCpoData {
+
+  public CassandraResultSetCpoData(MethodMapper<?> methodMapper, Object rs, CpoAttribute cpoAttribute, int index) {
+    super(methodMapper, rs, cpoAttribute, index);
+  }
+
+  protected Object invokeGetterImpl(MethodMapEntry<?, ?> methodMapEntry) throws IllegalAccessException, InvocationTargetException {
+    return methodMapEntry.getRsGetter().invoke(getRs(), getIndex());
+  }
+
+}

--- a/cpo-core/src/main/java/org/synchronoss/cpo/meta/AbstractCpoMetaAdapter.java
+++ b/cpo-core/src/main/java/org/synchronoss/cpo/meta/AbstractCpoMetaAdapter.java
@@ -124,6 +124,8 @@ public abstract class AbstractCpoMetaAdapter implements CpoMetaAdapter {
 
     if (attribute.getTransformInMethod() != null) {
       clazz = attribute.getTransformInMethod().getReturnType();
+    } else if (attribute.getGetterReturnType()!=null) {
+      clazz = attribute.getGetterReturnType();
     } else if (dataTypeMapEntry != null) {
       clazz = dataTypeMapEntry.getJavaClass();
     }

--- a/cpo-core/src/main/java/org/synchronoss/cpo/meta/MethodMapEntry.java
+++ b/cpo-core/src/main/java/org/synchronoss/cpo/meta/MethodMapEntry.java
@@ -56,24 +56,6 @@ public class MethodMapEntry<J,D> implements java.io.Serializable, Cloneable {
       this.rsGetter = rsGetter;
   }
 
-//  public void setBsSetter(String setterName) throws CpoException {
-//    try {
-//        bsSetter = B.class.getMethod(setterName, new Class[]{int.class, getJavaSqlMethodClass()});
-//    } catch (NoSuchMethodException nsme) {
-//      logger.error("Error loading Setter" + setterName, nsme);
-//      throw new CpoException(nsme);
-//    }
-//  }
-//
-//  public void setRsGetter(String getterName) throws CpoException {
-//    try {
-//      rsGetter = R.class.getMethod(getterName, new Class[]{int.class});
-//    } catch (NoSuchMethodException nsme) {
-//      logger.error("Error loading Getter" + getterName, nsme);
-//      throw new CpoException(nsme);
-//    }
-//  }
-//
   public Class<J> getJavaClass() {
     return javaClass_;
   }

--- a/cpo-core/src/main/java/org/synchronoss/cpo/meta/ResultSetCpoData.java
+++ b/cpo-core/src/main/java/org/synchronoss/cpo/meta/ResultSetCpoData.java
@@ -30,7 +30,7 @@ import java.lang.reflect.InvocationTargetException;
 /**
  * @author dberry
  */
-public class ResultSetCpoData extends AbstractBindableCpoData {
+public abstract class ResultSetCpoData extends AbstractBindableCpoData {
 
   private static final Logger logger = LoggerFactory.getLogger(ResultSetCpoData.class);
   private Object rs = null;
@@ -42,6 +42,12 @@ public class ResultSetCpoData extends AbstractBindableCpoData {
     this.rs = rs;
   }
 
+  public Object getRs() {
+    return rs;
+  }
+
+  protected abstract Object invokeGetterImpl(MethodMapEntry<?, ?> methodMapEntry) throws IllegalAccessException, InvocationTargetException;
+
   @Override
   public Object invokeGetter() throws CpoException {
     Object javaObject;
@@ -52,7 +58,7 @@ public class ResultSetCpoData extends AbstractBindableCpoData {
 
     try {
       // Get the getter for the Callable Statement
-      javaObject = transformIn(methodMapEntry.getRsGetter().invoke(rs, getIndex()));
+      javaObject = transformIn(invokeGetterImpl(methodMapEntry));
     } catch (IllegalAccessException iae) {
       logger.debug("Error Invoking ResultSet Method: " + ExceptionHelper.getLocalizedMessage(iae));
       throw new CpoException(iae);

--- a/cpo-core/src/main/java/org/synchronoss/cpo/meta/domain/CpoAttribute.java
+++ b/cpo-core/src/main/java/org/synchronoss/cpo/meta/domain/CpoAttribute.java
@@ -147,8 +147,8 @@ public class CpoAttribute extends CpoAttributeBean {
 
     try {
       setter_.invoke(instanceObject, cpoData.invokeGetter());
-    } catch (IllegalAccessException | InvocationTargetException e) {
-      localLogger.debug("Error Invoking Setter Method: " + ExceptionHelper.getLocalizedMessage(e));
+    } catch (IllegalAccessException | InvocationTargetException | IllegalArgumentException e) {
+      localLogger.debug("Error Invoking Setter Method: " + getDataName()+ ":" +getJavaName()+":"+setterName_ + ExceptionHelper.getLocalizedMessage(e));
     }
   }
 
@@ -165,13 +165,13 @@ public class CpoAttribute extends CpoAttributeBean {
   }
 
   private void dumpMethod(Method m) {
-    logger.debug("========================");
-    logger.debug("===> Declaring Class: " + m.getDeclaringClass().getName());
-    logger.debug("===> Method Signature: " + m.toString());
-    logger.debug("===> Generic Signature: " + m.toGenericString());
-    logger.debug("===> Method isBridge: " + m.isBridge());
-    logger.debug("===> Method isSynthetic: " + m.isSynthetic());
-    logger.debug("========================");
+    logger.trace("========================");
+    logger.trace("===> Declaring Class: " + m.getDeclaringClass().getName());
+    logger.trace("===> Method Signature: " + m.toString());
+    logger.trace("===> Generic Signature: " + m.toGenericString());
+    logger.trace("===> Method isBridge: " + m.isBridge());
+    logger.trace("===> Method isSynthetic: " + m.isSynthetic());
+    logger.trace("========================");
   }
 
   static public boolean isPrimitiveAssignableFrom(Class<?> clazz, Class<?> paramClass) {
@@ -223,6 +223,7 @@ public class CpoAttribute extends CpoAttributeBean {
           failedMessage.append("loadRunTimeInfo: Could not find a Getter:" + getGetterName() + "(" + metaClass.getName() + ")");
         } else {
           setGetter(methods.get(0));
+          dumpMethod(getGetter());
         }
       } catch (CpoException ce1) {
         failedMessage.append(ce1.getMessage());
@@ -233,6 +234,7 @@ public class CpoAttribute extends CpoAttributeBean {
         for (Method setter : findMethods(metaClass, getSetterName(), 1, false)) {
           if (setter.getParameterTypes()[0].isAssignableFrom(actualClass) || isPrimitiveAssignableFrom(setter.getParameterTypes()[0], actualClass)) {
             setSetter(setter);
+            dumpMethod(getSetter());
           }
         }
         if (getSetter() == null) {

--- a/cpo-jdbc/src/main/java/org/synchronoss/cpo/jdbc/JdbcCpoAdapter.java
+++ b/cpo-jdbc/src/main/java/org/synchronoss/cpo/jdbc/JdbcCpoAdapter.java
@@ -25,9 +25,9 @@ import org.synchronoss.cpo.*;
 import org.synchronoss.cpo.helper.ExceptionHelper;
 import org.synchronoss.cpo.jdbc.meta.JdbcCpoMetaDescriptor;
 import org.synchronoss.cpo.jdbc.meta.JdbcMethodMapper;
+import org.synchronoss.cpo.jdbc.meta.JdbcResultSetCpoData;
 import org.synchronoss.cpo.meta.CpoMetaDescriptor;
 import org.synchronoss.cpo.meta.DataTypeMapEntry;
-import org.synchronoss.cpo.meta.ResultSetCpoData;
 import org.synchronoss.cpo.meta.domain.*;
 
 import javax.naming.*;
@@ -1702,9 +1702,9 @@ public class JdbcCpoAdapter extends CpoBaseAdapter<DataSource> {
    * @throws CpoException Thrown if there are errors accessing the datasource
    */
   @Override
-  public <T, C> CpoResultSet<T> retrieveBeans(String name, C criteria, T result, Collection<CpoWhere> wheres, Collection<CpoOrderBy> orderBy, Collection<CpoNativeFunction> nativeExpressions, int queueSize) throws CpoException {
+  public <T, C> CpoResultSet<T> retrieveBeans(String name, C criteria, T result, Collection<CpoWhere> wheres, Collection<CpoOrderBy> orderBy, Collection<CpoNativeFunction> nativeExpressions, int queueSize) {
     CpoBlockingResultSet<T> resultSet = new CpoBlockingResultSet<>(queueSize);
-    RetrieverThread<T, C> retrieverThread = new RetrieverThread<>(name, criteria, result, wheres, orderBy, nativeExpressions, false, resultSet);
+    RetrieverThread<T, C> retrieverThread = new RetrieverThread<T,C>(name, criteria, result, wheres, orderBy, nativeExpressions, false, resultSet);
 
     retrieverThread.start();
     return resultSet;
@@ -2356,7 +2356,7 @@ public class JdbcCpoAdapter extends CpoBaseAdapter<DataSource> {
               attribute = (JdbcCpoAttribute) cpoClass.getAttributeData(rs.getString(1));
 
               if (attribute != null) {
-                attribute.invokeSetter(rObj, new ResultSetCpoData(JdbcMethodMapper.getMethodMapper(), rs, attribute, 2));
+                attribute.invokeSetter(rObj, new JdbcResultSetCpoData(JdbcMethodMapper.getMethodMapper(), rs, attribute, 2));
                 attributesSet++;
               }
             }
@@ -2367,7 +2367,7 @@ public class JdbcCpoAdapter extends CpoBaseAdapter<DataSource> {
               attribute = (JdbcCpoAttribute) cpoClass.getAttributeData(rsmd.getColumnLabel(k));
 
               if (attribute != null) {
-                attribute.invokeSetter(rObj, new ResultSetCpoData(JdbcMethodMapper.getMethodMapper(), rs, attribute, k));
+                attribute.invokeSetter(rObj, new JdbcResultSetCpoData(JdbcMethodMapper.getMethodMapper(), rs, attribute, k));
                 attributesSet++;
               }
             }
@@ -2537,7 +2537,7 @@ public class JdbcCpoAdapter extends CpoBaseAdapter<DataSource> {
 
           for (k = 1; k <= columnCount; k++) {
             if (attributes[k] != null) {
-              attributes[k].invokeSetter(obj, new ResultSetCpoData(JdbcMethodMapper.getMethodMapper(), rs, attributes[k], k));
+              attributes[k].invokeSetter(obj, new JdbcResultSetCpoData(JdbcMethodMapper.getMethodMapper(), rs, attributes[k], k));
             }
           }
 

--- a/cpo-jdbc/src/main/java/org/synchronoss/cpo/jdbc/JdbcPreparedStatementCpoData.java
+++ b/cpo-jdbc/src/main/java/org/synchronoss/cpo/jdbc/JdbcPreparedStatementCpoData.java
@@ -53,12 +53,13 @@ public class JdbcPreparedStatementCpoData extends AbstractBindableCpoData {
     Object param = transformOut(cpoAttribute.invokeGetter(instanceObject));
     JdbcMethodMapEntry<?,?> methodMapEntry = JdbcMethodMapper.getJavaSqlMethod(getDataSetterParamType());
     if (methodMapEntry == null) {
-      throw new CpoException("Error Retrieveing Jdbc Method for type: " + getDataSetterParamType().getName());
+      throw new CpoException("Error Retrieving Jdbc Method for type: " + getDataSetterParamType().getName());
     }
-    localLogger.info(cpoAttribute.getDataName() + "=" + param);
+    localLogger.debug(cpoAttribute.getDataName() + "=" + param);
     try {
       switch (methodMapEntry.getMethodType()) {
         case JdbcMethodMapEntry.METHOD_TYPE_BASIC:
+        case JdbcMethodMapEntry.METHOD_TYPE_OBJECT:
           methodMapEntry.getBsSetter().invoke(cpoStatementFactory.getPreparedStatement(), getIndex(), param);
           break;
         case JdbcMethodMapEntry.METHOD_TYPE_STREAM:
@@ -73,7 +74,7 @@ public class JdbcPreparedStatementCpoData extends AbstractBindableCpoData {
           break;
       }
     } catch (Exception e) {
-      throw new CpoException("Error Invoking Jdbc Method: " + methodMapEntry.getBsSetter().getName() + ":" + ExceptionHelper.getLocalizedMessage(e));
+      throw new CpoException("Error Invoking Jdbc Method: " + cpoAttribute.getDataName() + ":"+cpoAttribute.getJavaName()+":"+methodMapEntry.getBsSetter().getName() + ":" + ExceptionHelper.getLocalizedMessage(e));
     }
   }
 

--- a/cpo-jdbc/src/main/java/org/synchronoss/cpo/jdbc/meta/JdbcCpoMetaAdapter.java
+++ b/cpo-jdbc/src/main/java/org/synchronoss/cpo/jdbc/meta/JdbcCpoMetaAdapter.java
@@ -100,7 +100,7 @@ public class JdbcCpoMetaAdapter extends AbstractCpoMetaAdapter {
     // JDK 1.4.2 Values
     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.CHAR, "CHAR", String.class)); // 1
     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.LONGVARCHAR, "LONGVARCHAR", String.class)); // -1
-    dataTypeMapper.addDataTypeEntry(defaultDataTypeMapEntry); // 12
+    dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.VARCHAR, "VARCHAR", String.class)); // 12
     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.DECIMAL, "DECIMAL", BigDecimal.class)); // 3
     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.NUMERIC, "NUMERIC", BigDecimal.class)); // 2
     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.TINYINT, "TINYINT", byte.class)); // -6
@@ -122,11 +122,28 @@ public class JdbcCpoMetaAdapter extends AbstractCpoMetaAdapter {
     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.REF, "REF", java.sql.Ref.class)); // 2006
     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.DISTINCT, "DISTINCT", Object.class)); // 2001
     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.STRUCT, "STRUCT", Object.class)); // 2002
+//    dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.NULL, "NULL", Object.class)); // 0
     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.OTHER, "OTHER", Object.class)); // 1111
     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.JAVA_OBJECT, "JAVA_OBJECT", Object.class)); // 2000
     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.DATALINK, "DATALINK", java.net.URL.class)); // 70
     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.BIT, "BIT", boolean.class)); // -7
     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.BOOLEAN, "BOOLEAN", boolean.class)); //16
+
+    //------------------------- JDBC 4.0 -----------------------------------
+
+     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.ROWID, "ROWID", java.sql.RowId.class)); //-8
+     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.NCHAR, "NCHAR", String.class)); //-15
+     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.NVARCHAR, "NVARCHAR", String.class)); //-9
+     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.LONGNVARCHAR, "LONGNVARCHAR", String.class)); //-16
+     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.NCLOB, "NCLOB", java.sql.NClob.class)); //2011
+     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.SQLXML, "SQLXML", java.sql.SQLXML.class)); //2009
+
+     //--------------------------JDBC 4.2 -----------------------------
+
+     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.REF_CURSOR, "REF_CURSOR", java.sql.ResultSet.class)); //2012
+     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.TIME_WITH_TIMEZONE, "TIME_WITH_TIMEZONE", java.time.OffsetTime.class)); //2013;
+     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(java.sql.Types.TIMESTAMP_WITH_TIMEZONE, "TIMESTAMP_WITH_TIMEZONE", java.time.OffsetDateTime.class)); //2014
+
 
     // dbspecific types needed to generate the class from a function.
     dataTypeMapper.addDataTypeEntry(new DataTypeMapEntry<>(100, "VARCHAR_IGNORECASE", java.lang.String.class)); // HSQLDB TYPE for VARCHAR_IGNORE_CASE

--- a/cpo-jdbc/src/main/java/org/synchronoss/cpo/jdbc/meta/JdbcMethodMapEntry.java
+++ b/cpo-jdbc/src/main/java/org/synchronoss/cpo/jdbc/meta/JdbcMethodMapEntry.java
@@ -39,6 +39,7 @@ public class JdbcMethodMapEntry<J,D> extends MethodMapEntry<J,D> implements java
   private static final long serialVersionUID = 1L;
   public static final int METHOD_TYPE_STREAM = 1;
   public static final int METHOD_TYPE_READER = 2;
+  public static final int METHOD_TYPE_OBJECT = 3;
   private Method csGetter = null;
   private Method csSetter = null;
 

--- a/cpo-jdbc/src/main/java/org/synchronoss/cpo/jdbc/meta/JdbcResultSetCpoData.java
+++ b/cpo-jdbc/src/main/java/org/synchronoss/cpo/jdbc/meta/JdbcResultSetCpoData.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2003-2012 David E. Berry
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * A copy of the GNU Lesser General Public License may also be found at
+ * http://www.gnu.org/licenses/lgpl.txt
+ */
+package org.synchronoss.cpo.jdbc.meta;
+
+import org.synchronoss.cpo.meta.MethodMapEntry;
+import org.synchronoss.cpo.meta.MethodMapper;
+import org.synchronoss.cpo.meta.ResultSetCpoData;
+import org.synchronoss.cpo.meta.domain.CpoAttribute;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class JdbcResultSetCpoData extends ResultSetCpoData {
+
+  public JdbcResultSetCpoData(MethodMapper<?> methodMapper, Object rs, CpoAttribute cpoAttribute, int index) {
+    super(methodMapper, rs, cpoAttribute, index);
+  }
+
+  protected Object invokeGetterImpl(MethodMapEntry<?, ?> methodMapEntry) throws IllegalAccessException, InvocationTargetException {
+    Object javaObject=null;
+    switch (methodMapEntry.getMethodType()) {
+      case JdbcMethodMapEntry.METHOD_TYPE_BASIC:
+      case JdbcMethodMapEntry.METHOD_TYPE_STREAM:
+      case JdbcMethodMapEntry.METHOD_TYPE_READER:
+        javaObject = methodMapEntry.getRsGetter().invoke(getRs(), getIndex());
+        break;
+      case JdbcMethodMapEntry.METHOD_TYPE_OBJECT:
+        javaObject = methodMapEntry.getRsGetter().invoke(getRs(), getIndex(), methodMapEntry.getJavaClass());
+        break;
+    }
+    return javaObject;
+  }
+
+}

--- a/cpo-jdbc/src/test/java/org/synchronoss/cpo/jdbc/InsertObjectTest.java
+++ b/cpo-jdbc/src/test/java/org/synchronoss/cpo/jdbc/InsertObjectTest.java
@@ -27,7 +27,9 @@ import static org.junit.Assert.*;
 import org.synchronoss.cpo.*;
 import org.synchronoss.cpo.jdbc.meta.JdbcCpoMetaDescriptor;
 
+import java.math.BigInteger;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.*;
 
 /**
@@ -88,6 +90,10 @@ public class InsertObjectTest {
 
     valObj.setAttrBit(true);
 
+    // test the setObject and getObject type
+    BigInteger bigInteger = BigInteger.valueOf(1234);
+    valObj.setAttrBigInt(bigInteger);
+
     al.add(valObj);
 
     try {
@@ -100,6 +106,7 @@ public class InsertObjectTest {
       ValueObject vo = readAdapter.retrieveBean(null, valObj, valObj, null, null);
       assertTrue("Ids do not match", vo.getId() == valObj.getId());
       assertTrue("Integers do not match", vo.getAttrInteger() == valObj.getAttrInteger());
+      assertEquals("BigIntegers do not match", bigInteger, vo.getAttrBigInt());
       assertEquals("Strings do not match", vo.getAttrVarChar(), valObj.getAttrVarChar());
       assertEquals("Timestamps do not match", vo.getAttrDatetime(), valObj.getAttrDatetime());
       assertTrue("boolean not stored correctly", vo.getAttrBit());

--- a/cpo-jdbc/src/test/java/org/synchronoss/cpo/jdbc/ValueObject.java
+++ b/cpo-jdbc/src/test/java/org/synchronoss/cpo/jdbc/ValueObject.java
@@ -21,6 +21,7 @@
 package org.synchronoss.cpo.jdbc;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -72,7 +73,7 @@ public interface ValueObject {
 
   public int getAttrSmallInt();
 
-  public BigDecimal getAttrBigInt();
+  public BigInteger getAttrBigInt();
 
   public BigDecimal getAttrReal();
 
@@ -122,7 +123,7 @@ public interface ValueObject {
 
   public void setAttrSmallInt(int attrSmallInt);
 
-  public void setAttrBigInt(BigDecimal attrBigInt);
+  public void setAttrBigInt(BigInteger attrBigInt);
 
   public void setAttrReal(BigDecimal attrReal);
 

--- a/cpo-jdbc/src/test/java/org/synchronoss/cpo/jdbc/ValueObjectBean.java
+++ b/cpo-jdbc/src/test/java/org/synchronoss/cpo/jdbc/ValueObjectBean.java
@@ -21,6 +21,7 @@
 package org.synchronoss.cpo.jdbc;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.*;
 
 /**
@@ -53,7 +54,7 @@ public class ValueObjectBean implements ValueObject, java.io.Serializable, Clone
   private boolean attrBit_ = false;
   private BigDecimal attrTinyInt_ = null;
   private int attrSmallInt_ = 0;
-  private BigDecimal attrBigInt_ = null;
+  private BigInteger attrBigInt_ = null;
   private BigDecimal attrReal_ = null;
   private byte[] attrBinary_ = null;
   private byte[] attrVarBinary_ = null;
@@ -149,7 +150,7 @@ public class ValueObjectBean implements ValueObject, java.io.Serializable, Clone
     return attrSmallInt_;
   }
 
-  public BigDecimal getAttrBigInt() {
+  public BigInteger getAttrBigInt() {
     return attrBigInt_;
   }
 
@@ -249,7 +250,7 @@ public class ValueObjectBean implements ValueObject, java.io.Serializable, Clone
     attrSmallInt_ = attrSmallInt;
   }
 
-  public void setAttrBigInt(BigDecimal attrBigInt) {
+  public void setAttrBigInt(BigInteger attrBigInt) {
     attrBigInt_ = attrBigInt;
   }
 

--- a/cpo-jdbc/src/test/java/org/synchronoss/cpo/jdbc/WhereTest.java
+++ b/cpo-jdbc/src/test/java/org/synchronoss/cpo/jdbc/WhereTest.java
@@ -20,6 +20,7 @@
  */
 package org.synchronoss.cpo.jdbc;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.junit.After;
@@ -58,6 +59,8 @@ public class WhereTest {
     vo.setAttrVarChar("Test");
     vo.setAttrSmallInt(1);
     vo.setAttrInteger(1);
+    vo.setAttrBigInt(BigInteger.valueOf(2075L));
+    vo.setAttrDate(new java.sql.Date(new java.util.Date().getTime()));
     al.add(vo);
     al.add(new ValueObjectBean(2));
     al.add(new ValueObjectBean(3));
@@ -104,6 +107,26 @@ public class WhereTest {
       col = cpoAdapter.retrieveBeans("TestWhereRetrieve", valObj, wheres, null);
 
       assertTrue("Col size is " + col.size(), col.size() == 2);
+    } catch (Exception e) {
+      fail(method + e.getMessage());
+    }
+  }
+
+  @Test
+  public void testSetObjectWhere() {
+    String method = "testSetObjectWhere:";
+    Collection<ValueObject> col;
+    CpoWhere cw;
+
+    try {
+      BigInteger bigInt = BigInteger.valueOf(2075L);
+      cw = cpoAdapter.newWhere(CpoWhere.LOGIC_NONE, "attrBigInt", CpoWhere.COMP_EQ, bigInt);
+
+      ArrayList<CpoWhere> wheres = new ArrayList<>();
+      wheres.add(cw);
+      col = cpoAdapter.retrieveBeans("TestWhereRetrieve", new ValueObjectBean(), wheres, null);
+
+      assertTrue("Col size is " + col.size(), col.size() == 1);
     } catch (Exception e) {
       fail(method + e.getMessage());
     }

--- a/cpo-jdbc/src/test/java/org/synchronoss/cpo/jdbc/exporter/ExporterTest.java
+++ b/cpo-jdbc/src/test/java/org/synchronoss/cpo/jdbc/exporter/ExporterTest.java
@@ -98,6 +98,7 @@ public class ExporterTest {
       }
       assertTrue(found);
     } catch (CpoException e) {
+      e.printStackTrace();
       fail(e.getMessage());
     }
     logger.debug("testXmlExport complete");
@@ -137,6 +138,7 @@ public class ExporterTest {
       assertTrue(result);
 
     } catch (Exception e) {
+      e.printStackTrace();
       fail(e.getMessage());
     }
     logger.debug("testClassSourceExport complete");
@@ -176,6 +178,7 @@ public class ExporterTest {
       assertTrue(result);
 
     } catch (Exception e) {
+      e.printStackTrace();
       fail(e.getMessage());
     }
     logger.debug("testClassSourceExport complete");
@@ -233,6 +236,7 @@ public class ExporterTest {
       assertTrue(result);
 
     } catch (Exception e) {
+      e.printStackTrace();
       fail(e.getMessage());
     }
     logger.debug("testClassSourceExport complete");

--- a/cpo-jdbc/src/test/resources/h2/h2ValueMetaData.xml
+++ b/cpo-jdbc/src/test/resources/h2/h2ValueMetaData.xml
@@ -72,6 +72,14 @@
       <cpoj:dbColumn>id</cpoj:dbColumn>
     </cpoAttribute>
     <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">
+      <javaName>id</javaName>
+      <javaType>java.math.BigDecimal</javaType>
+      <dataName>ID</dataName>
+      <dataType>NUMERIC</dataType>
+      <cpoj:dbTable>value_object</cpoj:dbTable>
+      <cpoj:dbColumn>id</cpoj:dbColumn>
+    </cpoAttribute>
+    <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">
       <javaName>attrDouble</javaName>
       <javaType>double</javaType>
       <dataName>ATTR_DOUBLE</dataName>
@@ -105,6 +113,12 @@
       <transformClass>org.synchronoss.cpo.transform.jdbc.TransformNoOp</transformClass>
     </cpoAttribute>
     <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">
+      <javaName>attrBigInt</javaName>
+      <javaType>java.math.BigInteger</javaType>
+      <dataName>ATTR_BIGINT</dataName>
+      <dataType>BIGINT</dataType>
+    </cpoAttribute>
+    <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">
       <javaName>attrCharacter</javaName>
       <javaType>java.lang.String</javaType>
       <dataName>ATTR_CHARACTER</dataName>
@@ -112,7 +126,7 @@
     </cpoAttribute>
     <cpoFunctionGroup type="CREATE">
       <cpoFunction name="ValueObject - Create">
-        <expression>insert into value_object(id, attr_char, attr_character, attr_date, attr_decimal, attr_integer, attr_numeric, attr_smallint, attr_timestamp, attr_varchar, attr_bool, attr_datetime) values (?,?,?,?,?,?,?,?,?,?,?,?)</expression>
+        <expression>insert into value_object(id, attr_char, attr_character, attr_date, attr_decimal, attr_integer, attr_numeric, attr_smallint, attr_timestamp, attr_varchar, attr_bool, attr_datetime, attr_bigint) values (?,?,?,?,?,?,?,?,?,?,?,?,?)</expression>
         <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
           <attributeName>id</attributeName>
           <cpoj:scope>IN</cpoj:scope>
@@ -161,7 +175,11 @@
           <attributeName>attrDatetime</attributeName>
           <cpoj:scope>IN</cpoj:scope>
         </cpoArgument>
-      </cpoFunction>
+        <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
+          <attributeName>attrBigInt</attributeName>
+          <cpoj:scope>IN</cpoj:scope>
+        </cpoArgument>
+     </cpoFunction>
     </cpoFunctionGroup>
     <cpoFunctionGroup name="TestRollback" type="CREATE">
       <cpoFunction name="ValueObject - TestRollback">
@@ -254,7 +272,7 @@
     </cpoFunctionGroup>
     <cpoFunctionGroup name="TestOrderByInsert" type="CREATE">
       <cpoFunction name="TestOrderByInsert">
-        <expression>insert into value_object (id,attr_varchar,attr_smallint) values (?,?,?)</expression>
+        <expression>insert into value_object (id,attr_varchar,attr_smallint,attr_bigint) values (?,?,?,?)</expression>
         <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
           <attributeName>id</attributeName>
           <cpoj:scope>IN</cpoj:scope>
@@ -265,6 +283,10 @@
         </cpoArgument>
         <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
           <attributeName>attrSmallInt</attributeName>
+          <cpoj:scope>IN</cpoj:scope>
+        </cpoArgument>
+        <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
+          <attributeName>attrBigInt</attributeName>
           <cpoj:scope>IN</cpoj:scope>
         </cpoArgument>
       </cpoFunction>

--- a/cpo-jdbc/src/test/resources/mariadb/mariadbValueMetaData.xml
+++ b/cpo-jdbc/src/test/resources/mariadb/mariadbValueMetaData.xml
@@ -105,6 +105,12 @@
       <transformClass>org.synchronoss.cpo.transform.jdbc.TransformNoOp</transformClass>
     </cpoAttribute>
     <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">
+      <javaName>attrBigInt</javaName>
+      <javaType>java.math.BigInteger</javaType>
+      <dataName>attr_bigint</dataName>
+      <dataType>BIGINT</dataType>
+    </cpoAttribute>
+    <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">
       <javaName>attrCharacter</javaName>
       <javaType>java.lang.String</javaType>
       <dataName>attr_character</dataName>
@@ -112,7 +118,7 @@
     </cpoAttribute>
     <cpoFunctionGroup type="CREATE">
       <cpoFunction name="ValueObject - Create">
-        <expression>insert into value_object(id, attr_char, attr_character, attr_date, attr_decimal, attr_integer, attr_numeric, attr_smallint, attr_timestamp, attr_varchar, attr_bool, attr_datetime) values (?,?,?,?,?,?,?,?,?,?,?,?)</expression>
+        <expression>insert into value_object(id, attr_char, attr_character, attr_date, attr_decimal, attr_integer, attr_numeric, attr_smallint, attr_timestamp, attr_varchar, attr_bool, attr_datetime, attr_bigint) values (?,?,?,?,?,?,?,?,?,?,?,?,?)</expression>
         <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
           <attributeName>id</attributeName>
           <cpoj:scope>IN</cpoj:scope>
@@ -161,6 +167,10 @@
           <attributeName>attrDatetime</attributeName>
           <cpoj:scope>IN</cpoj:scope>
         </cpoArgument>
+      <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
+        <attributeName>attrBigInt</attributeName>
+        <cpoj:scope>IN</cpoj:scope>
+      </cpoArgument>
       </cpoFunction>
     </cpoFunctionGroup>
     <cpoFunctionGroup name="TestRollback" type="CREATE">
@@ -254,7 +264,7 @@
     </cpoFunctionGroup>
     <cpoFunctionGroup name="TestOrderByInsert" type="CREATE">
       <cpoFunction name="TestOrderByInsert">
-        <expression>insert into value_object (id,attr_varchar,attr_smallint) values (?,?,?)</expression>
+        <expression>insert into value_object (id,attr_varchar,attr_smallint, attr_bigint) values (?,?,?,?)</expression>
         <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
           <attributeName>id</attributeName>
           <cpoj:scope>IN</cpoj:scope>
@@ -265,6 +275,10 @@
         </cpoArgument>
         <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
           <attributeName>attrSmallInt</attributeName>
+          <cpoj:scope>IN</cpoj:scope>
+        </cpoArgument>
+        <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
+          <attributeName>attrBigInt</attributeName>
           <cpoj:scope>IN</cpoj:scope>
         </cpoArgument>
       </cpoFunction>

--- a/cpo-jdbc/src/test/resources/mariadb/mariadbValueMetaData.xml
+++ b/cpo-jdbc/src/test/resources/mariadb/mariadbValueMetaData.xml
@@ -167,10 +167,10 @@
           <attributeName>attrDatetime</attributeName>
           <cpoj:scope>IN</cpoj:scope>
         </cpoArgument>
-      <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
-        <attributeName>attrBigInt</attributeName>
-        <cpoj:scope>IN</cpoj:scope>
-      </cpoArgument>
+        <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
+          <attributeName>attrBigInt</attributeName>
+          <cpoj:scope>IN</cpoj:scope>
+        </cpoArgument>
       </cpoFunction>
     </cpoFunctionGroup>
     <cpoFunctionGroup name="TestRollback" type="CREATE">

--- a/cpo-jdbc/src/test/resources/mysql/mysqlValueMetaData.xml
+++ b/cpo-jdbc/src/test/resources/mysql/mysqlValueMetaData.xml
@@ -105,6 +105,12 @@
       <transformClass>org.synchronoss.cpo.transform.jdbc.TransformNoOp</transformClass>
     </cpoAttribute>
     <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">
+      <javaName>attrBigInt</javaName>
+      <javaType>java.math.BigInteger</javaType>
+      <dataName>attr_bigint</dataName>
+      <dataType>BIGINT</dataType>
+    </cpoAttribute>
+    <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">
       <javaName>attrCharacter</javaName>
       <javaType>java.lang.String</javaType>
       <dataName>attr_character</dataName>
@@ -112,7 +118,7 @@
     </cpoAttribute>
     <cpoFunctionGroup type="CREATE">
       <cpoFunction name="ValueObject - Create">
-        <expression>insert into value_object(id, attr_char, attr_character, attr_date, attr_decimal, attr_integer, attr_numeric, attr_smallint, attr_timestamp, attr_varchar, attr_bool, attr_datetime) values (?,?,?,?,?,?,?,?,?,?,?,?)</expression>
+        <expression>insert into value_object(id, attr_char, attr_character, attr_date, attr_decimal, attr_integer, attr_numeric, attr_smallint, attr_timestamp, attr_varchar, attr_bool, attr_datetime, attr_bigint) values (?,?,?,?,?,?,?,?,?,?,?,?,?)</expression>
         <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
           <attributeName>id</attributeName>
           <cpoj:scope>IN</cpoj:scope>
@@ -159,6 +165,10 @@
         </cpoArgument>
         <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
           <attributeName>attrDatetime</attributeName>
+          <cpoj:scope>IN</cpoj:scope>
+        </cpoArgument>
+        <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
+          <attributeName>attrBigInt</attributeName>
           <cpoj:scope>IN</cpoj:scope>
         </cpoArgument>
       </cpoFunction>
@@ -254,7 +264,7 @@
     </cpoFunctionGroup>
     <cpoFunctionGroup name="TestOrderByInsert" type="CREATE">
       <cpoFunction name="TestOrderByInsert">
-        <expression>insert into value_object (id,attr_varchar,attr_smallint) values (?,?,?)</expression>
+        <expression>insert into value_object (id,attr_varchar,attr_smallint, attr_bigint) values (?,?,?,?)</expression>
         <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
           <attributeName>id</attributeName>
           <cpoj:scope>IN</cpoj:scope>
@@ -265,6 +275,10 @@
         </cpoArgument>
         <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
           <attributeName>attrSmallInt</attributeName>
+          <cpoj:scope>IN</cpoj:scope>
+        </cpoArgument>
+        <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
+          <attributeName>attrBigInt</attributeName>
           <cpoj:scope>IN</cpoj:scope>
         </cpoArgument>
       </cpoFunction>

--- a/cpo-jdbc/src/test/resources/oracle/oracleValueMetaData.xml
+++ b/cpo-jdbc/src/test/resources/oracle/oracleValueMetaData.xml
@@ -101,6 +101,12 @@
       <cpoj:dbTable>value_object</cpoj:dbTable>
       <cpoj:dbColumn>attr_varchar</cpoj:dbColumn>
     </cpoAttribute>
+    <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">
+      <javaName>attrBigInt</javaName>
+      <javaType>java.math.BigInteger</javaType>
+      <dataName>attr_bigint</dataName>
+      <dataType>BIGINT</dataType>
+    </cpoAttribute>
     <cpoAttribute xsi:type="cpoj:ctJdbcAttribute" xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <javaName>id</javaName>
       <javaType>java.math.BigDecimal</javaType>
@@ -111,7 +117,7 @@
     </cpoAttribute>
     <cpoFunctionGroup type="CREATE">
       <cpoFunction name="ValueObject - Create">
-        <expression>insert into value_object(id, attr_char, attr_character, attr_date, ATTR_DECIMAL, ATTR_INTEGER, ATTR_NUMERIC, ATTR_SMALLINT, ATTR_TIMESTAMP, ATTR_VARCHAR, ATTR_BOOL, ATTR_DATETIME) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)</expression>
+        <expression>insert into value_object(id, attr_char, attr_character, attr_date, ATTR_DECIMAL, ATTR_INTEGER, ATTR_NUMERIC, ATTR_SMALLINT, ATTR_TIMESTAMP, ATTR_VARCHAR, ATTR_BOOL, ATTR_DATETIME, ATTR_BIGINT) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)</expression>
         <cpoArgument xsi:type="cpoj:ctJdbcArgument" xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
           <attributeName>id</attributeName>
           <cpoj:scope>IN</cpoj:scope>
@@ -158,6 +164,10 @@
         </cpoArgument>
         <cpoArgument xsi:type="cpoj:ctJdbcArgument" xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
           <attributeName>attrDatetime</attributeName>
+          <cpoj:scope>IN</cpoj:scope>
+        </cpoArgument>
+        <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="cpoj:ctJdbcArgument">
+          <attributeName>attrBigInt</attributeName>
           <cpoj:scope>IN</cpoj:scope>
         </cpoArgument>
       </cpoFunction>

--- a/cpo-jdbc/src/test/resources/postgres/initDB.sql
+++ b/cpo-jdbc/src/test/resources/postgres/initDB.sql
@@ -31,17 +31,23 @@ ID                      integer primary key
 ,ATTR_FLOAT              real        NULL
 ,ATTR_VARCHAR            varchar(255) NULL
 ,ATTR_VARCHAR_IGNORECASE varchar(255) NULL
-,ATTR_CHAR               varchar(255) NULL
-,ATTR_CHARACTER          varchar(255) NULL
+,ATTR_CHAR               char(255) NULL
+,ATTR_CHARACTER          character(255) NULL
 ,ATTR_DATE               date         NULL
-,ATTR_DATETIME			 timestamp	  NULL
+,ATTR_DATETIME			     timestamp	  NULL
 ,ATTR_TIME               time         NULL
+,ATTR_TIME_ZONE          time with time zone  NULL
 ,ATTR_TIMESTAMP          timestamp    NULL
+,ATTR_TIMESTAMP_ZONE     timestamp  with time zone  NULL
 ,ATTR_DECIMAL            decimal(10,0) NULL
-,ATTR_NUMERIC            decimal(10,0) NULL
-,ATTR_SMALLINT           smallint  NULL
+,ATTR_NUMERIC            numeric(10) NULL
+,ATTR_SMALLINT           smallint NULL
+,ATTR_BIGINT             bigint NULL
 ,ATTR_REAL               double precision     NULL
 ,ATTR_LONGTEXT           text     NULL
+--,ATTR_SMALLSERIAL        smallserial
+--,ATTR_SERIAL             serial
+--,ATTR_BIGSERIAL          bigserial
 );
 
 CREATE TABLE LOB_TEST (

--- a/cpo-jdbc/src/test/resources/postgres/postgresValueMetaData.xml
+++ b/cpo-jdbc/src/test/resources/postgres/postgresValueMetaData.xml
@@ -55,6 +55,18 @@
       <dataName>attr_timestamp</dataName>
       <dataType>TIMESTAMP</dataType>
     </cpoAttribute>
+<!--    <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">-->
+<!--      <javaName>attrTimestampZone</javaName>-->
+<!--      <javaType>java.time.OffsetDateTime</javaType>-->
+<!--      <dataName>attr_timestamp_zone</dataName>-->
+<!--      <dataType>TIMESTAMP_WITH_TIMEZONE</dataType>-->
+<!--    </cpoAttribute>-->
+<!--    <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">-->
+<!--      <javaName>attrTimeZone</javaName>-->
+<!--      <javaType>java.time.OffsetTime.class</javaType>-->
+<!--      <dataName>attr_time_zone</dataName>-->
+<!--      <dataType>TIME_WITH_TIMEZONE</dataType>-->
+<!--    </cpoAttribute>-->
     <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">
       <javaName>attrSmallInt</javaName>
       <javaType>short</javaType>
@@ -92,6 +104,14 @@
       <cpoj:dbColumn>attr_char</cpoj:dbColumn>
     </cpoAttribute>
     <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">
+      <javaName>attrCharacter</javaName>
+      <javaType>java.lang.String</javaType>
+      <dataName>attr_chararacter</dataName>
+      <dataType>CHAR</dataType>
+      <cpoj:dbTable>value_object</cpoj:dbTable>
+      <cpoj:dbColumn>attr_char</cpoj:dbColumn>
+    </cpoAttribute>
+    <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">
       <javaName>attrDecimal</javaName>
       <javaType>java.math.BigDecimal</javaType>
       <dataName>attr_decimal</dataName>
@@ -105,6 +125,12 @@
       <transformClass>org.synchronoss.cpo.transform.jdbc.TransformNoOp</transformClass>
     </cpoAttribute>
     <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">
+      <javaName>attrBigInt</javaName>
+      <javaType>java.math.BigInteger</javaType>
+      <dataName>attr_bigint</dataName>
+      <dataType>BIGINT</dataType>
+    </cpoAttribute>
+    <cpoAttribute xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcAttribute">
       <javaName>attrCharacter</javaName>
       <javaType>java.lang.String</javaType>
       <dataName>attr_character</dataName>
@@ -112,7 +138,7 @@
     </cpoAttribute>
     <cpoFunctionGroup type="CREATE">
       <cpoFunction name="ValueObject - Create">
-        <expression>insert into value_object(id, attr_char, attr_character, attr_date, attr_decimal, attr_integer, attr_numeric, attr_smallint, attr_timestamp, attr_varchar, attr_bool, attr_datetime) values (?,?,?,?,?,?,?,?,?,?,?,?)</expression>
+        <expression>insert into value_object(id, attr_char, attr_character, attr_date, attr_decimal, attr_integer, attr_numeric, attr_smallint, attr_timestamp, attr_varchar, attr_bool, attr_datetime, attr_bigint) values (?,?,?,?,?,?,?,?,?,?,?,?,?)</expression>
         <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
           <attributeName>id</attributeName>
           <cpoj:scope>IN</cpoj:scope>
@@ -159,6 +185,10 @@
         </cpoArgument>
         <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
           <attributeName>attrDatetime</attributeName>
+          <cpoj:scope>IN</cpoj:scope>
+        </cpoArgument>
+        <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
+          <attributeName>attrBigInt</attributeName>
           <cpoj:scope>IN</cpoj:scope>
         </cpoArgument>
       </cpoFunction>
@@ -254,7 +284,7 @@
     </cpoFunctionGroup>
     <cpoFunctionGroup name="TestOrderByInsert" type="CREATE">
       <cpoFunction name="TestOrderByInsert">
-        <expression>insert into value_object (id,attr_varchar,attr_smallint) values (?,?,?)</expression>
+        <expression>insert into value_object (id,attr_varchar,attr_smallint,attr_bigint) values (?,?,?,?)</expression>
         <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
           <attributeName>id</attributeName>
           <cpoj:scope>IN</cpoj:scope>
@@ -265,6 +295,10 @@
         </cpoArgument>
         <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
           <attributeName>attrSmallInt</attributeName>
+          <cpoj:scope>IN</cpoj:scope>
+        </cpoArgument>
+        <cpoArgument xmlns:cpoj="http://www.synchronoss.org/cpo/jdbc/CpoJdbcMeta.xsd" xsi:type="cpoj:ctJdbcArgument">
+          <attributeName>attrBigInt</attributeName>
           <cpoj:scope>IN</cpoj:scope>
         </cpoArgument>
       </cpoFunction>


### PR DESCRIPTION
- Added new JDBC Types
- Added Java Types that JDBC will convert using setObject(index) and
  getObject(index, Class<T>)
- Modified the ResultSet getters, PreparedStatementSetters and
  CallStatement getters and setters to use the new setObject and getObject facilities
- Added a new method mapper type for the setObject and getObject
  facilities
- Changed the exporter code to use the javaClass and not the dataClass
  as they can be different now.
- Added a test to test the setObject and getObject